### PR TITLE
Issue 1 / Default fix

### DIFF
--- a/R/automation.R
+++ b/R/automation.R
@@ -63,8 +63,6 @@ data.frame.lag.lead = function(dataframe, covariates,
 
   } else if (to.lag) {
 
-    if (nlags == 0) return(list(dataframe, c())) # do nothing
-
     # give placeholder variables the appropriate lagging values
     func = dplyr::lag
     prefix = "prev"
@@ -72,8 +70,6 @@ data.frame.lag.lead = function(dataframe, covariates,
     vec = vlags
 
   } else if (to.lead) {
-
-    if (nleads == 0) return(list(dataframe, c())) # do nothing
 
     # give placeholder variables the appropriate leading values
     func = dplyr::lead

--- a/R/automation.R
+++ b/R/automation.R
@@ -33,12 +33,11 @@ data.frame.lag.lead = function(dataframe, covariates,
   if (nlags > 0 | !is.null(vlags)) to.lag = TRUE else to.lag = FALSE
   if (nleads > 0 | !is.null(vleads)) to.lead = TRUE else to.lead = FALSE
 
-  if (nlags == 0 & nleads == 0 & is.null(vlags) & is.null(vlags)) {
+  if (!to.lag & !to.lead) {
 
     # if user does not specify any lag or lead arguments, default behavior
     # will be one lag
 
-    # give placeholder variables the appropriate lagging values
     func = dplyr::lag
     prefix = "prev"
     n.level = 1

--- a/R/automation.R
+++ b/R/automation.R
@@ -85,7 +85,6 @@ data.frame.lag.lead = function(dataframe, covariates,
     # entry for the first entry of animal 2
     dataframe = dataframe |>
       dplyr::group_by(!!rlang::sym(grouping))
-    group.count = length(unique(dataframe[[grouping]]))
   }
 
   # prepare names to be used in mutate & lag/lead functions:

--- a/R/automation.R
+++ b/R/automation.R
@@ -50,7 +50,7 @@ data.frame.lag.lead = function(dataframe, covariates,
             equivalents to change behavior")
 
   }
-  else if ((to.lag & to.lead) ) {
+  else if ((to.lag & to.lead)) {
 
     # recursively call function to lag and lead separately
     lagging = data.frame.lag.lead(dataframe, covariates, nlags = nlags, vlags = vlags,

--- a/R/automation.R
+++ b/R/automation.R
@@ -33,6 +33,8 @@ data.frame.lag.lead = function(dataframe, covariates,
   if (nlags > 0 | !is.null(vlags)) to.lag = TRUE else to.lag = FALSE
   if (nleads > 0 | !is.null(vleads)) to.lead = TRUE else to.lead = FALSE
 
+  new.covariates = vector()
+
   if (!to.lag & !to.lead) {
 
     # if user does not specify any lag or lead arguments, default behavior


### PR DESCRIPTION
If no lag/lead arguments given to function (only dataframe and covariates given), _default behavior_ is one lag with a warning() that the user should change the lag/lead arguments

Changed lag/lead boolean arguments to be controlled in function depending on whether user specifies any lag/lead arguments, instead of being specified by user

Also added a message() to print how many new lag/lead columns were made in the function